### PR TITLE
Update README.MD to include DIVI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,6 @@
 /src/e_x.egg-info/
 /electrumx.egg-info/
 /e_x.egg-info/
-
+electrumx-env/
 # Working Files directory
 Working Files/

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@
 electrumx-env/
 # Working Files directory
 Working Files/
+# Development notes
+.cursorrules

--- a/README.md
+++ b/README.md
@@ -20,6 +20,23 @@ arbitrary addresses. The server can be exposed publicly, and joined to the publi
 of servers via peer discovery. As of May 2020, a significant chunk of the public
 Electrum server network runs ElectrumX.
 
+## DIVI Vault Support
+
+This fork includes enhanced support for **DIVI coin** with full **vault transaction** support:
+
+- **DIVI Block Structure**: Handles DIVI's custom 112-byte block headers (vs standard 80 bytes)
+- **Vault Detection**: Automatically identifies and tracks DIVI vault transactions
+- **Enhanced Balance Queries**: Returns separate `vault_balance` and `spendable_balance` in balance responses
+- **UTXO Tracking**: Properly stores and retrieves vault flags with UTXO data
+- **Backward Compatibility**: Maintains compatibility with existing UTXO formats
+
+### DIVI-Specific Features
+
+- Custom block header deserialization with `acc_checkpoint` field support
+- Vault script detection and address extraction (owner/host addresses)
+- Dual hashing support: Quark hash for genesis block, Double SHA256 for subsequent blocks
+- Enhanced transaction parsing with vault metadata
+
 ### Documentation
 
 See [readthedocs](https://electrumx-spesmilo.readthedocs.io).

--- a/src/electrumx/lib/coins.py
+++ b/src/electrumx/lib/coins.py
@@ -2907,6 +2907,10 @@ class Divi(Coin):
     BASIC_HEADER_SIZE = 112  # 80 bytes standard + 32 bytes acc_checkpoint
     RPC_PORT = 51473
     REORG_LIMIT = 100
+    
+    # DIVI has fixed fees
+    ESTIMATE_FEE = 0.0001  # Fixed fee in DIVI
+    RELAY_FEE = 0.0001     # Fixed relay fee in DIVI
 
     @classmethod
     def header_hash(cls, header):

--- a/src/electrumx/lib/coins.py
+++ b/src/electrumx/lib/coins.py
@@ -2928,7 +2928,7 @@ class Divi(Coin):
                 return quark_hash.getPoWHash(header[:80])
             except ImportError:
                 try:
-                    import pivx_quark_hash as quark_hash
+        import pivx_quark_hash as quark_hash
                     return quark_hash.getPoWHash(header[:80])
                 except ImportError:
                     # Fallback to double SHA256

--- a/src/electrumx/lib/coins.py
+++ b/src/electrumx/lib/coins.py
@@ -2928,7 +2928,7 @@ class Divi(Coin):
                 return quark_hash.getPoWHash(header[:80])
             except ImportError:
                 try:
-        import pivx_quark_hash as quark_hash
+                    import pivx_quark_hash as quark_hash
                     return quark_hash.getPoWHash(header[:80])
                 except ImportError:
                     # Fallback to double SHA256

--- a/src/electrumx/lib/tx.py
+++ b/src/electrumx/lib/tx.py
@@ -1506,7 +1506,7 @@ class DeserializerDIVI(Deserializer):
         
         outputs = []
         for i in range(self._read_varint()):
-            value = self._read_le_int64()
+            value = self._read_le_uint64()
             pk_script = self._read_varbytes()
             
             # Detect script type and extract vault information

--- a/src/electrumx/lib/tx.py
+++ b/src/electrumx/lib/tx.py
@@ -1434,12 +1434,34 @@ class TxPIVX:
         ))
 
 
+class TxOutputDIVI:
+    """Class representing a DIVI transaction output with vault support."""
+    value: int
+    pk_script: bytes
+    script_type: str = "unknown"
+    vault_owner: str = None
+    vault_host: str = None
+
+    def __init__(self, value, pk_script, script_type="unknown", vault_owner=None, vault_host=None):
+        self.value = value
+        self.pk_script = pk_script
+        self.script_type = script_type
+        self.vault_owner = vault_owner
+        self.vault_host = vault_host
+
+    def serialize(self):
+        return b''.join((
+            pack_le_int64(self.value),
+            pack_varbytes(self.pk_script),
+        ))
+
+
 class TxDIVI:
     """Class representing a DIVI transaction."""
     __slots__ = 'version', 'inputs', 'outputs', 'locktime', 'txid', 'wtxid'
     version: int
     inputs: Sequence['TxInput']
-    outputs: Sequence['TxOutput']
+    outputs: Sequence['TxOutputDIVI']
     locktime: int
     txid: bytes
     wtxid: bytes
@@ -1470,13 +1492,46 @@ class DeserializerDIVI(Deserializer):
         start = self.cursor
         version = self._read_le_uint32()
         inputs = self._read_inputs()
-        outputs = self._read_outputs()
+        outputs = self._read_divi_outputs()
         locktime = self._read_le_uint32()
         
         # Calculate transaction ID
         txid = self.TX_HASH_FN(self.binary[start:self.cursor])
         
         return TxDIVI(version, inputs, outputs, locktime, txid, txid)
+    
+    def _read_divi_outputs(self):
+        """Read DIVI outputs with vault detection."""
+        from electrumx.lib.coins import Divi
+        
+        outputs = []
+        for i in range(self._read_varint()):
+            value = self._read_le_int64()
+            pk_script = self._read_varbytes()
+            
+            # Detect script type and extract vault information
+            script_type = "unknown"
+            vault_owner = None
+            vault_host = None
+            
+            if Divi.is_vault_script(pk_script):
+                script_type = "vault"
+                vault_owner, vault_host = Divi.extract_vault_addresses(pk_script)
+            elif len(pk_script) == 25 and pk_script[0] == 0x76 and pk_script[1] == 0xa9 and pk_script[22] == 0x88 and pk_script[23] == 0xac:
+                script_type = "pubkeyhash"
+            elif len(pk_script) == 23 and pk_script[0] == 0xa9 and pk_script[21] == 0x87:
+                script_type = "scripthash"
+            
+            output = TxOutputDIVI(
+                value=value,
+                pk_script=pk_script,
+                script_type=script_type,
+                vault_owner=vault_owner,
+                vault_host=vault_host
+            )
+            outputs.append(output)
+        
+        return outputs
     
     def read_header(self, static_header_size):
         """Return the DIVI block header bytes (112 bytes total)."""

--- a/src/electrumx/server/block_processor.py
+++ b/src/electrumx/server/block_processor.py
@@ -925,95 +925,63 @@ class DiviBlockProcessor(BlockProcessor):
         self.tip_advanced_event.clear()
 
     def advance_txs(self, txs: Sequence[Tx], is_unspendable: Callable[[bytes], bool]) -> Sequence[bytes]:
-        """Override to handle DIVI vault transactions with special indexing."""
-        # Call parent method first to handle standard processing
-        result = super().advance_txs(txs, is_unspendable)
-        
-        # Additional vault-specific processing
-        self._process_vault_transactions(txs, is_unspendable)
-        
-        return result
+        """Override to handle DIVI vault transactions with vault flag storage."""
+        self.tx_hashes.append(b''.join(tx.txid for tx in txs))
 
-    def _process_vault_transactions(self, txs: Sequence[Tx], is_unspendable: Callable[[bytes], bool]):
-        """Process vault transactions for additional indexing and metadata storage."""
-        from electrumx.lib.coins import Divi
-        
-        # Use local vars for speed
+        # Use local vars for speed in the loops
+        undo_info = []
+        tx_num = self.tx_count
+        script_hashX = self.coin.hashX_from_script
+        put_utxo = self.utxo_cache.__setitem__
+        spend_utxo = self.spend_utxo
+        undo_info_append = undo_info.append
         update_touched = self.touched.update
         hashXs_by_tx = []
         append_hashXs = hashXs_by_tx.append
-        
-        tx_num = self.tx_count - len(txs)
-        
+        to_le_uint32 = pack_le_uint32
+        to_le_uint64 = pack_le_uint64
+
         for tx in txs:
+            tx_hash = tx.txid
             hashXs = []
             append_hashX = hashXs.append
-            
-            # Check if this transaction has vault outputs
-            has_vault_outputs = False
-            vault_metadata = {
-                'owner_key': None,
-                'host_key': None,
-                'vault_count': 0
-            }
-            
-            # Process outputs for vault detection
-            for txout in tx.outputs:
-                # Skip unspendable outputs
+            tx_numb = to_le_uint64(tx_num)[:TXNUM_LEN]
+
+            # Spend the inputs
+            for txin in tx.inputs:
+                if txin.is_generation():
+                    continue
+                cache_value = spend_utxo(txin.prev_hash, txin.prev_idx)
+                undo_info_append(cache_value)
+                append_hashX(cache_value[:HASHX_LEN])
+
+            # Add the new UTXOs with vault flags
+            for idx, txout in enumerate(tx.outputs):
+                # Ignore unspendable outputs
                 if is_unspendable(txout.pk_script):
                     continue
+
+                # Get the hashX
+                hashX = script_hashX(txout.pk_script)
+                append_hashX(hashX)
                 
-                # Check if this is a vault output
+                # Check if this is a vault UTXO
+                is_vault = False
                 if hasattr(txout, 'script_type') and txout.script_type == 'vault':
-                    has_vault_outputs = True
-                    vault_metadata['vault_count'] += 1
-                    
-                    # Store vault metadata
-                    if hasattr(txout, 'vault_owner') and txout.vault_owner:
-                        vault_metadata['owner_key'] = txout.vault_owner
-                    if hasattr(txout, 'vault_host') and txout.vault_host:
-                        vault_metadata['host_key'] = txout.vault_host
-                    
-                    # For vault outputs, we need to index both owner and host keys
-                    # Owner key is already handled by the parent method via hashX_from_script
-                    # Here we add the host key for additional indexing
-                    
-                    if hasattr(txout, 'vault_host') and txout.vault_host:
-                        try:
-                            # Convert host address to hashX for indexing
-                            host_hashX = self.coin.address_to_hashX(txout.vault_host)
-                            append_hashX(host_hashX)
-                            
-                            # Log vault transaction for debugging
-                            self.logger.debug(f'Vault transaction detected: '
-                                            f'owner={txout.vault_owner}, '
-                                            f'host={txout.vault_host}, '
-                                            f'txid={tx.txid.hex()}')
-                        except Exception as e:
-                            self.logger.warning(f'Failed to process vault host address {txout.vault_host}: {e}')
-            
-            # Store vault metadata for enhanced balance responses
-            if has_vault_outputs:
-                self._store_vault_metadata(tx.txid, vault_metadata)
-            
+                    is_vault = True
+                
+                # Create UTXO with vault flag
+                vault_flag = 1 if is_vault else 0
+                utxo_value = hashX + tx_numb + to_le_uint64(txout.value) + bytes([vault_flag])
+                put_utxo(tx_hash + to_le_uint32(idx), utxo_value)
+
             append_hashXs(hashXs)
             update_touched(hashXs)
             tx_num += 1
-        
-        # Add vault-specific hashXs to history for additional indexing
-        if hashXs_by_tx:
-            self.db.history.add_unflushed(hashXs_by_tx, self.tx_count - len(txs))
 
-    def _store_vault_metadata(self, txid: bytes, vault_metadata: dict):
-        """Store vault metadata for enhanced balance responses.
-        
-        This could be stored in a separate database table or cache
-        for quick retrieval during balance queries.
-        """
-        # For now, just log the metadata
-        # In a full implementation, this would store to a vault_metadata table
-        self.logger.debug(f'Storing vault metadata for {txid.hex()}: {vault_metadata}')
-        
-        # TODO: Implement vault metadata storage
-        # This would enable the HTTP wrapper to quickly determine
-        # vault vs regular transaction breakdown for addresses
+        self.db.history.add_unflushed(hashXs_by_tx, self.tx_count)
+
+        self.tx_count = tx_num
+        self.db.tx_counts.append(tx_num)
+
+        return undo_info

--- a/src/electrumx/server/block_processor.py
+++ b/src/electrumx/server/block_processor.py
@@ -650,7 +650,15 @@ class BlockProcessor:
         idx_packed = pack_le_uint32(tx_idx)
         cache_value = self.utxo_cache.pop(tx_hash + idx_packed, None)
         if cache_value:
-            return cache_value
+            # Handle both old and new UTXO formats in cache
+            if len(cache_value) == 24:  # HASHX_LEN + TXNUM_LEN + 8
+                # Old format - return as-is
+                return cache_value
+            elif len(cache_value) == 25:  # HASHX_LEN + TXNUM_LEN + 9
+                # New format - strip the vault flag
+                return cache_value[:-1]
+            else:
+                raise ChainError(f'Invalid cached UTXO length: {len(cache_value)}')
 
         # Spend it from the DB.
         txnum_padding = bytes(8-TXNUM_LEN)
@@ -679,7 +687,16 @@ class BlockProcessor:
                 # Remove both entries for this UTXO
                 self.db_deletes.append(hdb_key)
                 self.db_deletes.append(udb_key)
-                return hashX + tx_num_packed + utxo_value_packed
+                
+                # Handle both old and new UTXO formats
+                if len(utxo_value_packed) == 8:
+                    # Old format - just the value
+                    return hashX + tx_num_packed + utxo_value_packed
+                elif len(utxo_value_packed) == 9:
+                    # New format - strip the vault flag
+                    return hashX + tx_num_packed + utxo_value_packed[:8]
+                else:
+                    raise ChainError(f'Invalid UTXO value length: {len(utxo_value_packed)}')
 
         raise ChainError(f'UTXO {hash_to_hex_str(tx_hash)} / {tx_idx:,d} not '
                          f'found in "h" table')
@@ -926,62 +943,38 @@ class DiviBlockProcessor(BlockProcessor):
 
     def advance_txs(self, txs: Sequence[Tx], is_unspendable: Callable[[bytes], bool]) -> Sequence[bytes]:
         """Override to handle DIVI vault transactions with vault flag storage."""
-        self.tx_hashes.append(b''.join(tx.txid for tx in txs))
-
-        # Use local vars for speed in the loops
-        undo_info = []
-        tx_num = self.tx_count
-        script_hashX = self.coin.hashX_from_script
+        # Call the parent method to handle all the standard logic
+        undo_info = super().advance_txs(txs, is_unspendable)
+        
+        # Now update the UTXOs we just created to include vault flags
+        tx_num = self.tx_count - len(txs)
         put_utxo = self.utxo_cache.__setitem__
-        spend_utxo = self.spend_utxo
-        undo_info_append = undo_info.append
-        update_touched = self.touched.update
-        hashXs_by_tx = []
-        append_hashXs = hashXs_by_tx.append
         to_le_uint32 = pack_le_uint32
         to_le_uint64 = pack_le_uint64
-
+        script_hashX = self.coin.hashX_from_script
+        
         for tx in txs:
             tx_hash = tx.txid
-            hashXs = []
-            append_hashX = hashXs.append
-            tx_numb = to_le_uint64(tx_num)[:TXNUM_LEN]
-
-            # Spend the inputs
-            for txin in tx.inputs:
-                if txin.is_generation():
-                    continue
-                cache_value = spend_utxo(txin.prev_hash, txin.prev_idx)
-                undo_info_append(cache_value)
-                append_hashX(cache_value[:HASHX_LEN])
-
-            # Add the new UTXOs with vault flags
+            
+            # Update UTXOs with vault flags
             for idx, txout in enumerate(tx.outputs):
                 # Ignore unspendable outputs
                 if is_unspendable(txout.pk_script):
                     continue
-
-                # Get the hashX
+                
+                # Get the hashX for this output
                 hashX = script_hashX(txout.pk_script)
-                append_hashX(hashX)
                 
-                # Check if this is a vault UTXO
-                is_vault = False
-                if hasattr(txout, 'script_type') and txout.script_type == 'vault':
-                    is_vault = True
+                # Check if this is a vault UTXO by examining the script directly
+                is_vault = self.coin.is_vault_script(txout.pk_script)
                 
-                # Create UTXO with vault flag
+                # Create complete UTXO with vault flag
                 vault_flag = 1 if is_vault else 0
-                utxo_value = hashX + tx_numb + to_le_uint64(txout.value) + bytes([vault_flag])
-                put_utxo(tx_hash + to_le_uint32(idx), utxo_value)
-
-            append_hashXs(hashXs)
-            update_touched(hashXs)
+                tx_numb = to_le_uint64(tx_num)[:TXNUM_LEN]
+                utxo_value = to_le_uint64(txout.value) + bytes([vault_flag])
+                complete_utxo = hashX + tx_numb + utxo_value
+                put_utxo(tx_hash + to_le_uint32(idx), complete_utxo)
+            
             tx_num += 1
-
-        self.db.history.add_unflushed(hashXs_by_tx, self.tx_count)
-
-        self.tx_count = tx_num
-        self.db.tx_counts.append(tx_num)
-
+        
         return undo_info

--- a/src/electrumx/server/db.py
+++ b/src/electrumx/server/db.py
@@ -96,7 +96,7 @@ class DB:
         self.history = History()
 
         # Key: b'u' + address_hashX + txout_idx + tx_num
-        # Value: the UTXO value as a 64-bit unsigned integer (in satoshis)
+        # Value: the UTXO value as a 64-bit unsigned integer + vault flag (8 or 9 bytes)
         # "at address, at outpoint, there is a UTXO of value v"
         # ---
         # Key: b'h' + compressed_tx_hash + txout_idx + tx_num
@@ -331,11 +331,21 @@ class DB:
         # New UTXOs
         batch_put = batch.put
         for key, value in flush_data.adds.items():
-            # key: txid+out_idx, value: hashX+tx_num+value_sats
+            # key: txid+out_idx, value: hashX+tx_num+value_sats+vault_flag
             hashX = value[:HASHX_LEN]
             txout_idx = key[-4:]
             tx_num = value[HASHX_LEN: HASHX_LEN+TXNUM_LEN]
-            value_sats = value[-8:]
+            
+            # Handle both old and new UTXO formats
+            if len(value) == HASHX_LEN + TXNUM_LEN + 8:
+                # Old format - just value (8 bytes)
+                value_sats = value[-8:]
+            elif len(value) == HASHX_LEN + TXNUM_LEN + 9:
+                # New format - value + vault_flag (9 bytes)
+                value_sats = value[-9:]  # Keep the vault flag
+            else:
+                raise ValueError(f"Invalid UTXO value length: {len(value)}")
+            
             suffix = txout_idx + tx_num
             batch_put(b'h' + key[:COMP_TXID_LEN] + suffix, hashX)
             batch_put(b'u' + hashX + suffix, value_sats)
@@ -763,20 +773,16 @@ class DB:
                 
                 # Handle both old and new UTXO formats
                 if len(db_value) == 8:
-                    # Very old format - just the value
+                    # Original ElectrumX format - just the value
                     value, = unpack_le_uint64(db_value)
                     is_vault = False
-                elif len(db_value) == 23:
-                    # Original ElectrumX format - hashX + tx_numb + value
-                    value, = unpack_le_uint64(db_value[-8:])  # Last 8 bytes are the value
-                    is_vault = False
-                elif len(db_value) == 24:
-                    # New DIVI format - hashX + tx_numb + value + vault_flag
-                    value, = unpack_le_uint64(db_value[-9:-1])  # 8 bytes before the last byte
-                    vault_flag = db_value[-1]  # Last byte is the vault flag
+                elif len(db_value) == 9:
+                    # New DIVI format - value + vault_flag
+                    value, = unpack_le_uint64(db_value[:8])  # First 8 bytes are the value
+                    vault_flag = db_value[8]  # Last byte is the vault flag
                     is_vault = bool(vault_flag)
                 else:
-                    raise ValueError(f"Invalid UTXO value length: {len(db_value)}, expected 8, 23, or 24 bytes")
+                    raise ValueError(f"Invalid UTXO value length: {len(db_value)}, expected 8 or 9 bytes")
                 
                 tx_hash, height = self.fs_tx_hash(tx_num)
                 utxos_append(UTXO(tx_num, txout_idx, tx_hash, height, value, is_vault))
@@ -826,14 +832,24 @@ class DB:
                     # that new block
                     return None
                 # Key: b'u' + address_hashX + tx_idx + tx_num
-                # Value: the UTXO value as a 64-bit unsigned integer
+                # Value: the UTXO value as a 64-bit unsigned integer + vault flag
                 key = b'u' + hashX + suffix
                 db_value = self.utxo_db.get(key)
                 if not db_value:
                     # This can happen if the DB was updated between
                     # getting the hashXs and getting the UTXOs
                     return None
-                value, = unpack_le_uint64(db_value)
+                
+                # Handle both old and new UTXO formats
+                if len(db_value) == 8:
+                    # Original ElectrumX format - just the value
+                    value, = unpack_le_uint64(db_value)
+                elif len(db_value) == 9:
+                    # New DIVI format - value + vault_flag
+                    value, = unpack_le_uint64(db_value[:8])  # First 8 bytes are the value
+                else:
+                    raise ValueError(f"Invalid UTXO value length: {len(db_value)}, expected 8 or 9 bytes")
+                
                 return hashX, value
             return [lookup_utxo(*hashX_pair) for hashX_pair in hashX_pairs]
 

--- a/src/electrumx/server/db.py
+++ b/src/electrumx/server/db.py
@@ -762,12 +762,8 @@ class DB:
                 tx_num, = unpack_le_uint64(db_key[-TXNUM_LEN:] + txnum_padding)
                 
                 # Handle both old and new UTXO formats
-                if len(db_value) == 8:
-                    # Original ElectrumX format - just the value
-                    value, = unpack_le_uint64(db_value)
-                    is_vault = False
-                elif len(db_value) == 23:
-                    # Old DIVI format - hashX + tx_numb + value
+                if len(db_value) == 23:
+                    # Original ElectrumX format - hashX + tx_numb + value
                     value, = unpack_le_uint64(db_value[-8:])  # Last 8 bytes are the value
                     is_vault = False
                 elif len(db_value) == 24:
@@ -776,7 +772,7 @@ class DB:
                     vault_flag = db_value[-1]  # Last byte is the vault flag
                     is_vault = bool(vault_flag)
                 else:
-                    raise ValueError(f"Invalid UTXO value length: {len(db_value)}, expected 8, 23, or 24 bytes")
+                    raise ValueError(f"Invalid UTXO value length: {len(db_value)}, expected 23 or 24 bytes")
                 
                 tx_hash, height = self.fs_tx_hash(tx_num)
                 utxos_append(UTXO(tx_num, txout_idx, tx_hash, height, value, is_vault))

--- a/src/electrumx/server/db.py
+++ b/src/electrumx/server/db.py
@@ -762,7 +762,11 @@ class DB:
                 tx_num, = unpack_le_uint64(db_key[-TXNUM_LEN:] + txnum_padding)
                 
                 # Handle both old and new UTXO formats
-                if len(db_value) == 23:
+                if len(db_value) == 8:
+                    # Very old format - just the value
+                    value, = unpack_le_uint64(db_value)
+                    is_vault = False
+                elif len(db_value) == 23:
                     # Original ElectrumX format - hashX + tx_numb + value
                     value, = unpack_le_uint64(db_value[-8:])  # Last 8 bytes are the value
                     is_vault = False
@@ -772,7 +776,7 @@ class DB:
                     vault_flag = db_value[-1]  # Last byte is the vault flag
                     is_vault = bool(vault_flag)
                 else:
-                    raise ValueError(f"Invalid UTXO value length: {len(db_value)}, expected 23 or 24 bytes")
+                    raise ValueError(f"Invalid UTXO value length: {len(db_value)}, expected 8, 23, or 24 bytes")
                 
                 tx_hash, height = self.fs_tx_hash(tx_num)
                 utxos_append(UTXO(tx_num, txout_idx, tx_hash, height, value, is_vault))

--- a/src/electrumx/server/db.py
+++ b/src/electrumx/server/db.py
@@ -762,21 +762,21 @@ class DB:
                 tx_num, = unpack_le_uint64(db_key[-TXNUM_LEN:] + txnum_padding)
                 
                 # Handle both old and new UTXO formats
-                # Format: hashX + tx_numb + value [+ vault_flag]
-                expected_old_len = HASHX_LEN + TXNUM_LEN + 8  # hashX + tx_numb + value
-                expected_new_len = expected_old_len + 1  # + vault_flag
-                
-                if len(db_value) == expected_old_len:
-                    # Old format - assume regular UTXO
+                if len(db_value) == 8:
+                    # Original ElectrumX format - just the value
+                    value, = unpack_le_uint64(db_value)
+                    is_vault = False
+                elif len(db_value) == 23:
+                    # Old DIVI format - hashX + tx_numb + value
                     value, = unpack_le_uint64(db_value[-8:])  # Last 8 bytes are the value
                     is_vault = False
-                elif len(db_value) == expected_new_len:
-                    # New format - read vault flag
+                elif len(db_value) == 24:
+                    # New DIVI format - hashX + tx_numb + value + vault_flag
                     value, = unpack_le_uint64(db_value[-9:-1])  # 8 bytes before the last byte
                     vault_flag = db_value[-1]  # Last byte is the vault flag
                     is_vault = bool(vault_flag)
                 else:
-                    raise ValueError(f"Invalid UTXO value length: {len(db_value)}, expected {expected_old_len} or {expected_new_len}")
+                    raise ValueError(f"Invalid UTXO value length: {len(db_value)}, expected 8, 23, or 24 bytes")
                 
                 tx_hash, height = self.fs_tx_hash(tx_num)
                 utxos_append(UTXO(tx_num, txout_idx, tx_hash, height, value, is_vault))

--- a/src/electrumx/server/session.py
+++ b/src/electrumx/server/session.py
@@ -1403,6 +1403,11 @@ class ElectrumX(SessionBase):
         '''The minimum fee a low-priority tx must pay in order to be accepted
         to the daemon's memory pool.'''
         self.bump_cost(1.0)
+        
+        # For DIVI, use fixed relay fee instead of asking daemon
+        if hasattr(self.coin, 'RELAY_FEE'):
+            return self.coin.RELAY_FEE
+            
         return await self.daemon_request('relayfee')
 
     async def estimatefee(self, number, mode=None):
@@ -1417,6 +1422,10 @@ class ElectrumX(SessionBase):
         if mode not in self.coin.ESTIMATEFEE_MODES:
             raise RPCError(BAD_REQUEST, f'unknown estimatefee mode: {mode}')
         self.bump_cost(0.1)
+
+        # For DIVI, use fixed fee instead of dynamic estimation
+        if hasattr(self.coin, 'ESTIMATE_FEE'):
+            return self.coin.ESTIMATE_FEE
 
         number = self.coin.bucket_estimatefee_block_target(number)
         cache = self.session_mgr.estimatefee_cache


### PR DESCRIPTION
Update README.MD to include DIVI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds full DIVI vault support across parsing, indexing, storage, and API.
> 
> - Introduces `TxOutputDIVI`/`TxDIVI` and updates `DeserializerDIVI` to detect vault scripts, extract owner/host, and parse DIVI's 112-byte headers
> - Enhances `DiviBlockProcessor` to set a vault flag on created UTXOs; maintains backward compatibility by handling both 8-byte and 9-byte UTXO value formats
> - Updates DB layer (`UTXO` dataclass, reads/writes) to store/retrieve vault flags and expose `is_vault` via `all_utxos`
> - Extends session API `get_balance`/`scripthash_get_balance` to return `breakdown` with `vault_balance` and `spendable_balance`
> - Adds fixed fee handling for DIVI via `ESTIMATE_FEE`/`RELAY_FEE` and returns these in `estimatefee`/`relayfee` when available
> - README: documents DIVI vault support and specifics; `.gitignore` tweaks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c03b4933dd09c6de736af1df00b57d9b22d95e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->